### PR TITLE
Set a theme that overwrites windows 11 force themeing in dark mode.

### DIFF
--- a/bw_editor.py
+++ b/bw_editor.py
@@ -1168,6 +1168,9 @@ if __name__ == "__main__":
         import platform
         import argparse
         from PyQt6.QtCore import QLocale
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtGui import QPalette, QColor
+        from PyQt6.QtCore import Qt
 
         QLocale.setDefault(QLocale(QLocale.Language.English))
 
@@ -1181,6 +1184,24 @@ if __name__ == "__main__":
         os.environ['QT_ENABLE_HIGHDPI_SCALING'] = '0'
         app = QApplication(sys.argv)
 
+        app.setStyle('Fusion')
+        palette = QPalette()
+
+        palette.setColor(QPalette.ColorRole.Window, QColor(53, 53, 53))
+        palette.setColor(QPalette.ColorRole.WindowText, Qt.GlobalColor.white)
+        palette.setColor(QPalette.ColorRole.Base, QColor(35, 35, 35))
+        palette.setColor(QPalette.ColorRole.AlternateBase, QColor(53, 53, 53))
+        palette.setColor(QPalette.ColorRole.ToolTipBase, Qt.GlobalColor.white)
+        palette.setColor(QPalette.ColorRole.ToolTipText, Qt.GlobalColor.white)
+        palette.setColor(QPalette.ColorRole.Text, Qt.GlobalColor.white)
+        palette.setColor(QPalette.ColorRole.Button, QColor(53, 53, 53))
+        palette.setColor(QPalette.ColorRole.ButtonText, Qt.GlobalColor.white)
+        palette.setColor(QPalette.ColorRole.BrightText, Qt.GlobalColor.red)
+        palette.setColor(QPalette.ColorRole.Link, QColor(42, 130, 218))
+        palette.setColor(QPalette.ColorRole.Highlight, QColor(42, 130, 218))
+        palette.setColor(QPalette.ColorRole.HighlightedText, Qt.GlobalColor.black)
+
+        app.setPalette(palette)
         if platform.system() == "Windows":
             import ctypes
             myappid = 'BWEditor'  # arbitrary string

--- a/bw_widgets.py
+++ b/bw_widgets.py
@@ -145,18 +145,35 @@ class FPSCounter(QtWidgets.QLabel):
         font.setStyleHint(QFont.StyleHint.Monospace)
         font.setFixedPitch(True)
         font.setPointSize(20)
+        font.setBold(True)
 
-        metrics = QFontMetrics(font)
         self.setFont(font)
-        self.setStyleSheet("""QLabel {color: #000000}""")
-        #self.setVisible(False)
-        #self.reset()
+        self.move(posx, posy)
         self.frametime_total = 1
         self.frametime_terrain = 0
         self.frametime_objects = 0
         self.frametime_liveedit = 0
-        self.move(posx, posy)
         self.update_frametime()
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        # Get the bounding rectangle and expand it to fit the outline, and shift it 10 pixels to the right
+        rect = self.rect().adjusted(10, -2, 2, 2)  # Offset 10 pixels to the right, expand slightly vertically
+
+        # Draw the outline with a shift of 1 pixel in each direction
+        outline_color = QColor(255, 255, 255)
+        painter.setPen(outline_color)
+
+        # Draw the text with shifts of 1 pixel in all directions
+        for dx, dy in [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]:
+            painter.drawText(rect.adjusted(dx, dy, dx, dy), Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                             self.text())
+
+        text_color = QColor(0, 0, 0)
+        painter.setPen(text_color)
+        painter.drawText(rect, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter, self.text())
+        painter.end()
 
     def toggle_visible(self):
         if self.isVisible():
@@ -203,7 +220,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
         #self.setMinimumSize(QSize(self.SIZEX, self.SIZEY))
         #self.setMaximumSize(QSize(self.SIZEX, self.SIZEY))
         self.setObjectName("bw_map_screen")
-        self.fpscounter = FPSCounter(0, 50, self)
+        self.fpscounter = FPSCounter(0, 10, self)
         self.origin_x = self.SIZEX//2
         self.origin_z = self.SIZEY//2
 


### PR DESCRIPTION
Adds dark theme fixes issue with memory debug when windows 11 is in dark mode being un seeable.