### PR TITLE
Add search feature with highlighting and result count

### DIFF
--- a/default_path2.cfg
+++ b/default_path2.cfg
@@ -1,0 +1,1 @@
+C:/Users/sambe/Desktop/ALL_BW1and2_STUFF/BW2STUFF/bw2MODDED/DATA/files/Data/Strings/frontend2English.str

--- a/plugins/strings_editor/bw_strings_editor.py
+++ b/plugins/strings_editor/bw_strings_editor.py
@@ -20,6 +20,76 @@ import PyQt5.QtCore as QtCore
 from plugins.strings_editor.strings import BWLanguageFile, Message
 
 
+class HighlightDelegate(QtWidgets.QStyledItemDelegate):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.search_text = ""
+
+    def set_search_text(self, text):
+        self.search_text = text.lower()
+
+    def paint(self, painter, option, index):
+        painter.save()
+
+        # Draw background (selected, hover, etc.)
+        style = option.widget.style() if option.widget else QtWidgets.QApplication.style()
+        style.drawControl(QtWidgets.QStyle.ControlElement.CE_ItemViewItem, option, painter, option.widget)
+
+        text = index.data(QtCore.Qt.ItemDataRole.DisplayRole)
+        if not text:
+            painter.restore()
+            return
+
+        text_rect = style.subElementRect(QtWidgets.QStyle.SubElement.SE_ItemViewItemText, option, option.widget)
+        painter.setFont(option.font)
+
+        text_color = option.palette.color(
+            QtGui.QPalette.ColorGroup.Normal,
+            QtGui.QPalette.ColorRole.HighlightedText if option.state & QtWidgets.QStyle.StateFlag.State_Selected
+            else QtGui.QPalette.ColorRole.Text
+        )
+
+        if not self.search_text or self.search_text not in text.lower():
+            # No match, draw normally
+            painter.setPen(text_color)
+            painter.drawText(text_rect, QtCore.Qt.AlignmentFlag.AlignVCenter, text)
+        else:
+            # Draw text with highlighted match
+            lower_text = text.lower()
+            match_start = lower_text.find(self.search_text)
+            match_end = match_start + len(self.search_text)
+
+            fm = QtGui.QFontMetrics(option.font)
+            x = text_rect.x()
+            y = text_rect.y()
+            h = text_rect.height()
+
+            before = text[:match_start]
+            match = text[match_start:match_end]
+            after = text[match_end:]
+
+            before_w = fm.horizontalAdvance(before)
+            match_w = fm.horizontalAdvance(match)
+
+            # Draw text before match
+            painter.setPen(text_color)
+            painter.drawText(QtCore.QRect(x, y, before_w, h), QtCore.Qt.AlignmentFlag.AlignVCenter, before)
+
+            # Draw yellow highlight behind matched text
+            highlight_rect = QtCore.QRect(x + before_w, y + 2, match_w, h - 4)
+            painter.fillRect(highlight_rect, QtGui.QColor(255, 200, 0, 180))
+
+            # Draw matched text in black so it's readable on yellow
+            painter.setPen(QtGui.QColor(0, 0, 0))
+            painter.drawText(QtCore.QRect(x + before_w, y, match_w, h), QtCore.Qt.AlignmentFlag.AlignVCenter, match)
+
+            # Draw text after match
+            painter.setPen(text_color)
+            painter.drawText(QtCore.QRect(x + before_w + match_w, y, text_rect.width(), h), QtCore.Qt.AlignmentFlag.AlignVCenter, after)
+
+        painter.restore()
+
+
 class BWEntityEntry(QtWidgets.QListWidgetItem):
     def __init__(self, xml_ref, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -75,6 +145,7 @@ class StringsEditorMainWindow(QtWidgets.QMainWindow):
         self.button_set_message.pressed.connect(self.action_button_set_message)
         self.button_add_message.pressed.connect(self.action_button_add_message)
         self.button_remove_message.pressed.connect(self.action_button_delete_message)
+        self.search_bar.textChanged.connect(self.action_search)
 
     def reset(self):
         self.reset_in_process = True
@@ -85,9 +156,38 @@ class StringsEditorMainWindow(QtWidgets.QMainWindow):
         self.lineedit_path.clear()
         self.lineedit_playtime.clear()
         self.lineedit_audioname.clear()
+        self.search_bar.clear()
+        self.search_count_label.setText("")
 
         self.curr_path = None
         self.reset_in_process = False
+
+    def action_search(self, text):
+        self.highlight_delegate.set_search_text(text)
+        self.strings_list.viewport().update()
+
+        text_lower = text.lower()
+        match_count = 0
+
+        for i in range(self.strings_list.count()):
+            item = self.strings_list.item(i)
+            if self.stringfile is not None:
+                msg = self.stringfile.messages[item.xml_ref]
+                match = (
+                    text_lower in msg.get_message().lower() or
+                    text_lower in msg.get_path().lower() or
+                    text_lower in msg.get_name().lower()
+                )
+                item.setHidden(not match)
+                if match:
+                    match_count += 1
+            else:
+                item.setHidden(False)
+
+        if text_lower:
+            self.search_count_label.setText("{0} result{1}".format(match_count, "s" if match_count != 1 else ""))
+        else:
+            self.search_count_label.setText("")
 
     def action_button_add_message(self):
         if self.stringfile is not None:
@@ -231,17 +331,34 @@ class StringsEditorMainWindow(QtWidgets.QMainWindow):
         self.setMinimumSize(QtCore.QSize(720, 560))
         self.setWindowTitle("BW-StringsEdit")
 
-
         self.centralwidget = QtWidgets.QWidget(self)
         self.centralwidget.setObjectName("centralwidget")
         self.setCentralWidget(self.centralwidget)
 
-
         self.horizontalLayout = QtWidgets.QHBoxLayout(self.centralwidget)
         self.horizontalLayout.setObjectName("horizontalLayout")
 
-        self.strings_list = QtWidgets.QListWidget(self.centralwidget)
-        self.horizontalLayout.addWidget(self.strings_list)
+        # Left side: search bar + list
+        self.left_widget = QtWidgets.QWidget(self.centralwidget)
+        self.left_layout = QtWidgets.QVBoxLayout(self.left_widget)
+        self.left_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Search row: search bar + result count label
+        self.search_row = QtWidgets.QHBoxLayout()
+        self.search_bar = QtWidgets.QLineEdit(self.left_widget)
+        self.search_bar.setPlaceholderText("Search messages, paths, filenames...")
+        self.search_count_label = QtWidgets.QLabel("")
+        self.search_count_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignVCenter | QtCore.Qt.AlignmentFlag.AlignRight)
+        self.search_row.addWidget(self.search_bar)
+        self.search_row.addWidget(self.search_count_label)
+        self.left_layout.addLayout(self.search_row)
+
+        self.strings_list = QtWidgets.QListWidget(self.left_widget)
+        self.highlight_delegate = HighlightDelegate(self.strings_list)
+        self.strings_list.setItemDelegate(self.highlight_delegate)
+        self.left_layout.addWidget(self.strings_list)
+
+        self.horizontalLayout.addWidget(self.left_widget)
 
         self.vertLayoutWidget = QtWidgets.QWidget(self.centralwidget)
         self.verticalLayout = QtWidgets.QVBoxLayout(self.vertLayoutWidget)
@@ -258,19 +375,15 @@ class StringsEditorMainWindow(QtWidgets.QMainWindow):
         self.lineedit_playtime = QtWidgets.QLineEdit(self.centralwidget)
         self.textedit_content = QtWidgets.QTextEdit(self.centralwidget)
 
-        for widget in ( self.button_remove_message, self.button_add_message, self.button_set_message,
+        for widget in (self.button_remove_message, self.button_add_message, self.button_set_message,
                        self.lineedit_path, self.lineedit_audioname, self.lineedit_playtime, self.textedit_content):
             self.verticalLayout.addWidget(widget)
 
         self.horizontalLayout.addWidget(self.vertLayoutWidget)
 
-        self.menubar = self.menuBar()#QMenuBar(self)
-        #self.menubar.setGeometry(QRect(0, 0, 820, 30))
-        #self.menubar.setObjectName("menubar")
-        self.file_menu = self.menubar.addMenu("File")#QMenu(self.menubar)
+        self.menubar = self.menuBar()
+        self.file_menu = self.menubar.addMenu("File")
         self.file_menu.setObjectName("menuLoad")
-        #self.menubar.addMenu(self.file_menu)
-
 
         self.file_load_action = QtGui.QAction("Load", self)
         self.file_load_action.triggered.connect(self.button_load_strings)
@@ -287,7 +400,6 @@ class StringsEditorMainWindow(QtWidgets.QMainWindow):
         self.statusbar.setObjectName("statusbar")
         self.setStatusBar(self.statusbar)
 
-        #self.setMenuBar(self.menubar)
         print("done")
 
 
@@ -295,7 +407,6 @@ if __name__ == "__main__":
     import sys
 
     app = QtWidgets.QApplication(sys.argv)
-
 
     bw_gui = StringsEditorMainWindow()
 


### PR DESCRIPTION
## Added a search feature to the strings editor list.

A search bar has been added above the message list that filters results in real-time as you type. It searches across all three fields — message content, audio path, and audio filename — so you don't have to know where the text lives.

As you type, matching text in each visible list item is highlighted in yellow so you can instantly see what matched. A result count label sits to the right of the search bar showing how many items match your current query **(e.g. "5 results")**, which clears when the search box is empty.

https://github.com/user-attachments/assets/55e159aa-1ae4-4c8f-9b9f-ce81faeb45ff